### PR TITLE
fix: adds support for http2 responses

### DIFF
--- a/src/Client/ClientSSL.php
+++ b/src/Client/ClientSSL.php
@@ -194,7 +194,7 @@ class ClientSSL extends Client
         curl_close($curl);
 
         // Check for 200 Code in $contents
-        if (!strstr($contents, '200 OK')) {
+        if (!strstr($contents, '200 OK') && !strstr($contents, 'HTTP/2 200')) {
             //There was no "200 OK" returned - we failed
             return $this->handleError(-32300, 'transport error - HTTP status code was not 200');
         }


### PR DESCRIPTION
http2+ responses don't contain status text in first line, instead they just contain the http version followed by status code, this PR fixes it.

Fixes #9