### PR TITLE
fix non-canonical casts

### DIFF
--- a/src/Message/Message.php
+++ b/src/Message/Message.php
@@ -145,7 +145,7 @@ class Message
                 $valueFlag = true;
                 break;
             case 'double':
-                $value = (double)trim($this->_currentTagContents);
+                $value = (float)trim($this->_currentTagContents);
                 $valueFlag = true;
                 break;
             case 'string':
@@ -164,7 +164,7 @@ class Message
                 }
                 break;
             case 'boolean':
-                $value = (boolean)trim($this->_currentTagContents);
+                $value = (bool)trim($this->_currentTagContents);
                 $valueFlag = true;
                 break;
             case 'base64':


### PR DESCRIPTION
On PHP 8.5 two deprecation warnings were thrown because of the casts to double and boolean. The canonical types in PHP are float and bool. This fixes the issue.