### PR TITLE
only manually free the XML parser on PHP <8

### DIFF
--- a/src/Message/Message.php
+++ b/src/Message/Message.php
@@ -82,7 +82,11 @@ class Message
                 break;
             }
         } while (true);
-        xml_parser_free($this->_parser);
+        if(PHP_VERSION_ID < 80000) {
+            // Manually freeing the XML parser is only necessary in PHP versions prior to 8.0
+            xml_parser_free($this->_parser);
+            unset($this->_parser); // release the reference to the parser
+        }
 
         // Grab the error messages, if any
         if ($this->messageType === 'fault') {


### PR DESCRIPTION
On PHP 8.5 using xml_parser_free() would throw the following deprecation warning:

Function xml_parser_free() is deprecated since 8.5, as it has no effect since PHP 8.0

https://www.php.net/manual/en/function.xml-parser-free.php also points out that the reference to the parser needs to be released after freeing to avoid memory leaks:

> Caution In addition to calling xml_parser_free() when the parsing is
> finished, prior to PHP 8.0.0, it was necessary to also explicitly
> unset the reference to parser to avoid memory leaks, if the parser
> resource is referenced from an object, and this object references
> that parser resource.

This patch does a PHP version check. An alternative would be to increase the minimum required version in composer.json and simply remove the call to xml_parser_free